### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+
+sudo: false


### PR DESCRIPTION
This enables us to use the [TravisCI](https://travis-ci.org) integration server. 

@mgodave I have activated it for my forked repo, but you should probably activate it for this repo to. Have a look at http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in for instructions.