### PR TITLE
some command is not "api" or "bgapi"

### DIFF
--- a/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -302,7 +302,7 @@ public class Client implements IModEslApi {
 
 		try {
 			if (clientContext.isPresent()) {
-				return new CommandResponse("exit", clientContext.get().sendApiCommand("exit", null));
+				return new CommandResponse("exit", clientContext.get().sendCommand("exit"));
 			} else {
 				throw new IllegalStateException("not connected/authenticated");
 			}

--- a/src/main/java/org/freeswitch/esl/client/internal/Context.java
+++ b/src/main/java/org/freeswitch/esl/client/internal/Context.java
@@ -44,7 +44,7 @@ public class Context implements IModEslApi {
 
 		try {
 
-			return getUnchecked(handler.sendApiSingleLineCommand(channel, command.toUpperCase().trim()));
+			return getUnchecked(handler.sendApiSingleLineCommand(channel, command.toLowerCase().trim()));
 
 		} catch (Throwable t) {
 			throw propagate(t);

--- a/src/main/java/org/freeswitch/esl/client/internal/Context.java
+++ b/src/main/java/org/freeswitch/esl/client/internal/Context.java
@@ -35,7 +35,7 @@ public class Context implements IModEslApi {
 	 * <p/>
 	 * The outcome of the command from the server is returned in an {@link org.freeswitch.esl.client.transport.message.EslMessage} object.
 	 *
-	 * @param command API command to send
+	 * @param command a mod_event_socket command to send
 	 * @return an {@link org.freeswitch.esl.client.transport.message.EslMessage} containing command results
 	 */
 	public EslMessage sendCommand(String command) {

--- a/src/main/java/org/freeswitch/esl/client/internal/Context.java
+++ b/src/main/java/org/freeswitch/esl/client/internal/Context.java
@@ -30,6 +30,28 @@ public class Context implements IModEslApi {
 	}
 
 	/**
+	 * Sends a mod_event_socket command to FreeSWITCH server and blocks, waiting for an immediate response from the
+	 * server.
+	 * <p/>
+	 * The outcome of the command from the server is returned in an {@link org.freeswitch.esl.client.transport.message.EslMessage} object.
+	 *
+	 * @param command API command to send
+	 * @return an {@link org.freeswitch.esl.client.transport.message.EslMessage} containing command results
+	 */
+	public EslMessage sendCommand(String command) {
+
+		checkArgument(!isNullOrEmpty(command), "command cannot be null or empty");
+
+		try {
+
+			return getUnchecked(handler.sendApiSingleLineCommand(channel, command.toUpperCase().trim()));
+
+		} catch (Throwable t) {
+			throw propagate(t);
+		}
+	}
+
+	/**
 	 * Sends a FreeSWITCH API command to the server and blocks, waiting for an immediate response from the
 	 * server.
 	 * <p/>


### PR DESCRIPTION
some mod_event_socket command is not "api" or "bgapi", such as "exit".

I want to add a **sendCommand** method for it.